### PR TITLE
38 fix bugs

### DIFF
--- a/include/defines.hpp
+++ b/include/defines.hpp
@@ -5,11 +5,11 @@
 # define NETWORK			"42 IRC"
 # define VERSION			"eval-42.42"
 
-# define LOG_RAW_CMDS		0	// '1': Commands as sent by users are logged; '0': not logged
+# define LOG_RAW_CMDS		0	// '1': Commands as sent by users are logged; '0': not logged --> Good for Debugging!
 
 # define BOT_NAME			"IRCbot"
 # define BOT_COLOR			"\033[38;5;214m"	// Orange color for bot messages
-# define BOT_SILENT_NOTE	1	// '1': No logging of bot NOTICE messages; '0': log them
+# define BOT_SILENT_NOTE	1	// '1': No logging of bot NOTICE messages; '0': log them; helps to avoid cluttering the log
 
 # define MAX_CHANNELS		10		// Max channels per user; recommended in RFC 1459, 1.3
 # define C_MODES			"itkol"	// Supported channel modes, as per subject

--- a/src/Command.cpp
+++ b/src/Command.cpp
@@ -81,7 +81,7 @@ preserving the trailing parameter (after a colon `:`).
 This function splits an IRC line like:
 	"   USER max 0   * :Max Power  the Third"
  into:
-	["USER", "max", "0", "*", ":Max Power  the Third"]
+	["USER", "max", "0", "*", "Max Power  the Third"]
 
 If a token starts with a colon (`:`), the rest of the line (including spaces) is treated
 as a single argument (the trailing parameter), as per IRC protocol.
@@ -108,7 +108,7 @@ std::vector<std::string>	Command::tokenize(const std::string& message)
 		if (message[pos] == ':')
 		{
 			if (pos + 1 < message.size()) // Only push trailing param if there is something after ':'
-				tokens.push_back(message.substr(pos)); // Add the rest of the line as one token
+				tokens.push_back(message.substr(pos + 1)); // Add the rest of the line as one token
 			break; // No more tokens
 		}
 

--- a/src/CommandChannel.cpp
+++ b/src/CommandChannel.cpp
@@ -172,8 +172,6 @@ bool	Command::handleJoin(Server* server, User* user, const std::vector<std::stri
 	if (tokens.size() >= 3)
 	{
 		std::string	keyList = tokens[2];
-		if (!keyList.empty() && keyList[0] == ':') // Check if key list starts with ':' (trailing parameter)
-			keyList = keyList.substr(1); // Remove leading ':'
 		keys = splitCommaList(keyList);
 	}
 
@@ -299,8 +297,6 @@ bool Command::handlePart(Server* server, User* user, const std::vector<std::stri
 				partMessage += " ";
 			partMessage += tokens[i];
 		}
-		if (!partMessage.empty() && partMessage[0] == ':')
-			partMessage = partMessage.substr(1);
 	}
 
 	// Process each channel
@@ -431,9 +427,6 @@ bool	Command::handleKick(Server* server, User* user, const std::vector<std::stri
 				kickReason += " ";
 			kickReason += tokens[i];
 		}
-		// Remove leading ':' if present (trailing parameter)
-		if (!kickReason.empty() && kickReason[0] == ':')
-			kickReason = kickReason.substr(1);
 	}
 
 	// Send KICK message to all channel members (including kicker and victim)
@@ -521,8 +514,6 @@ bool	Command::handleTopic(Server *server, User *user, const std::vector<std::str
 	if (tokens.size() > 2)
 	{
 		std::string	newTopic = tokens[2];
-		if (newTopic[0] == ':')
-			newTopic = newTopic.substr(1); // Remove leading ':', if present
 		if (channel->has_topic_protection() && !channel->is_user_operator(user))
 		{
 			user->logUserAction(toString("tried to set topic for ") + BLUE + channelNameOrig + RESET

--- a/src/CommandConnection.cpp
+++ b/src/CommandConnection.cpp
@@ -15,8 +15,6 @@ static std::string	getQuitReason(const std::vector<std::string>& tokens)
 		return "Client Quit";	// Default reason if none provided
 
 	std::string	reason = tokens[1];
-	if (reason[0] == ':')	// Remove leading ':' if present
-		reason = reason.substr(1);
 	return reason;
 }
 

--- a/src/CommandMessaging.cpp
+++ b/src/CommandMessaging.cpp
@@ -177,10 +177,21 @@ void Command::handleMessageToUser(Server* server, User* sender, const std::strin
 	if (sender->getIsBot() && !botCmd.empty())
 		logCmd += " (" + botCmd + ")";
 
+	// not connected
 	if (!targetUser)
 	{
 		sender->logUserAction("tried to send " + logCmd
 			+ " to non-existing " + RED + targetNick + RESET);
+		if (sendReplies)
+			sender->sendError(401, targetNick, "No such nick/channel");
+		return;
+	}
+
+	// On server but not yet registered
+	if (!targetUser->isRegistered())
+	{
+		sender->logUserAction("tried to send " + logCmd
+			+ " to not registered " + RED + targetNick + RESET);
 		if (sendReplies)
 			sender->sendError(401, targetNick, "No such nick/channel");
 		return;

--- a/src/CommandMessaging.cpp
+++ b/src/CommandMessaging.cpp
@@ -168,18 +168,20 @@ void Command::handleMessageToUser(Server* server, User* sender, const std::strin
 	const bool	sendReplies = (commandName == "PRIVMSG");
 	User*		targetUser = server->getUser(normalize(targetNick));
 
-	if (BOT_SILENT_NOTE && commandName == "NOTICE" && sender->getIsBot())
-		return; // Do not log bot NOTICE messages
-
 	std::string	logCmd = commandName;
 	if (sender->getIsBot() && !botCmd.empty())
 		logCmd += " (" + botCmd + ")";
 
+	bool	logAction = true;
+	if (BOT_SILENT_NOTE && commandName == "NOTICE" && sender->getIsBot())
+		logAction = false; // Do not log bot NOTICE messages
+
 	// not connected
 	if (!targetUser)
 	{
-		sender->logUserAction("tried to send " + logCmd
-			+ " to non-existing " + RED + targetNick + RESET);
+		if (logAction)
+			sender->logUserAction("tried to send " + logCmd
+				+ " to non-existing " + RED + targetNick + RESET);
 		if (sendReplies)
 			sender->sendError(401, targetNick, "No such nick/channel");
 		return;
@@ -188,8 +190,9 @@ void Command::handleMessageToUser(Server* server, User* sender, const std::strin
 	// On server but not yet registered
 	if (!targetUser->isRegistered())
 	{
-		sender->logUserAction("tried to send " + logCmd
-			+ " to not registered " + RED + targetNick + RESET);
+		if (logAction)
+			sender->logUserAction("tried to send " + logCmd
+				+ " to not registered " + RED + targetNick + RESET);
 		if (sendReplies)
 			sender->sendError(401, targetNick, "No such nick/channel");
 		return;
@@ -204,12 +207,14 @@ void Command::handleMessageToUser(Server* server, User* sender, const std::strin
 		std::string	dccInfo = message.substr(1, message.size() - 2); // remove leading and trailing 0x01
 		std::vector<std::string>	tokens = Command::tokenize(dccInfo);
 	
-		sender->logUserAction(toString("sent DCC-SEND to ") + GREEN + targetUser->getNickname() + RESET
-			+ ": " + YELLOW + tokens[2] + " (" + tokens[5] + " bytes)" + RESET, sender->getIsBot());
+		if (logAction)
+			sender->logUserAction(toString("sent DCC-SEND to ") + GREEN + targetUser->getNickname() + RESET
+				+ ": " + YELLOW + tokens[2] + " (" + tokens[5] + " bytes)" + RESET, sender->getIsBot());
 	}
 	else
 	{
-		sender->logUserAction("sent " + logCmd + " to user "
-			+ GREEN + targetUser->getNickname() + RESET, sender->getIsBot());
+		if (logAction)
+			sender->logUserAction("sent " + logCmd + " to user "
+				+ GREEN + targetUser->getNickname() + RESET, sender->getIsBot());
 	}
 }

--- a/src/CommandMessaging.cpp
+++ b/src/CommandMessaging.cpp
@@ -45,8 +45,6 @@ void	Command::handleMessage(Server* server, User* user, const std::vector<std::s
 
 	// Get message
 	std::string	message = tokens[2];
-	if (!message.empty() && message[0] == ':')
-		message = message.substr(1); // Remove leading ':' if present
 
 	// Send message to each target
 	std::vector<std::string>	targets = splitCommaList(tokens[1]);

--- a/src/CommandRegistration.cpp
+++ b/src/CommandRegistration.cpp
@@ -90,10 +90,7 @@ void	Command::handleUser(User* user, const std::vector<std::string>& tokens)
 	user->setUsername(tokens[1]);
 
 	// Handle realname
-	std::string	realname = tokens[4];
-	if (realname[0] == ':') // Remove leading colon if present
-		realname = realname.substr(1);
-	user->setRealname(realname);
+	user->setRealname(tokens[4]);
 
 	user->tryRegister();
 }


### PR DESCRIPTION
- move to removing of `;` in trailing parameters into the tokenization function --> makes everything easier (avoid mutliple manual removal for specific commands), and now also allows for server password with spaces, for example (which did't work before)
- user on the server but not registered yet cannot receive PRIVMSG / NOTICE now
- bot sends welcome note to user joining channel now, also when the BOT_SILENT_NOTE flag is on (not logging of these actions to avoid cluttering of logs)